### PR TITLE
feat: add group trip template MDX content

### DIFF
--- a/.cursor/rules/viajes-en-grupo-template.mdc
+++ b/.cursor/rules/viajes-en-grupo-template.mdc
@@ -1,0 +1,17 @@
+---
+description: Use group trip MDX template for new group trips
+globs: src/content/viajes-en-grupo/**/*.mdx
+alwaysApply: false
+---
+
+# Viajes en grupo: usar plantilla base
+
+Cuando se cree un nuevo viaje en grupo, usar siempre como base `.templates/plantilla-viaje-en-grupo.mdx`.
+
+## Instrucciones
+
+- Copiar la plantilla completa y crear el nuevo archivo en `src/content/viajes-en-grupo/`.
+- Mantener la misma estructura de secciones y componentes (itinerario, precios, incluye/excluye, vuelos, pagos, observaciones).
+- Reemplazar todos los placeholders por contenido real del viaje antes de finalizar.
+- Verificar que el `id` del frontmatter sea unico y coherente con el slug.
+- No publicar la plantilla dentro de `src/content/viajes-en-grupo/`; la plantilla vive en `.templates/`.

--- a/.templates/plantilla-viaje-en-grupo.mdx
+++ b/.templates/plantilla-viaje-en-grupo.mdx
@@ -1,0 +1,143 @@
+---
+id: "plantilla-viaje-en-grupo"
+title: "Título del viaje"
+description: "Breve descripción SEO atractiva del viaje."
+date: "2026-01-01"
+image: "assets/continente/pais/ciudad/nombre"
+category: "europe"
+tags: ["viajes-en-grupo", "pais", "cultura"]
+location: ["Ciudad1", "Ciudad2"]
+---
+
+<Columns columns={2}>
+  <ColumnItem>
+    Aquí va una **introducción** al viaje. Describe lo más destacado y por qué es una experiencia única. Utiliza **negritas** para resaltar conceptos clave.
+
+    ¿Te apuntas a esta aventura por **País**?
+  </ColumnItem>
+
+  <ColumnItem>
+    ![Mapa del viaje](assets/continente/pais/ciudad/mapa)
+  </ColumnItem>
+</Columns>
+
+## Itinerario
+
+<Timeline mode="alternate">
+  <TimelineItem date="Día 1" title="Origen - Destino" image="assets/continente/pais/ciudad/foto1">
+    Descripción del primer día. Llegada, traslado al hotel y primeras actividades. **Cena incluida**.
+  </TimelineItem>
+
+  <TimelineItem date="Día 2" title="Nombre de la ciudad o actividad" image="assets/continente/pais/ciudad/foto2">
+    **Desayuno**. Descripción de las visitas del día. **Almuerzo en ruta**. Regreso al hotel y **alojamiento**.
+  </TimelineItem>
+
+  {/* Añadir más TimelineItem según los días del viaje */}
+</Timeline>
+
+> **Nota importante:** Los programas descritos son susceptibles de cambios por razones puntuales ajenas a nuestra organización, tales como condiciones meteorológicas o de seguridad.
+
+## Precios
+
+<PricingGrid>
+  <PricingItem title="Precio base" price="0.000 €" subtitle="por persona" highlight={true}>
+    
+    ##### 🛡️ Incluye Seguro Básico
+      - Gastos médicos: 4.500 €
+      - Gastos de anulación: 500 €
+    
+    <Button title="GARANTIAS" icon="fa-solid fa-shield-halved" link="#" className="pricing-button" />
+    
+  </PricingItem>
+
+  <PricingItem title="Suplemento individual" price="000 €" subtitle="bajo petición">
+
+      - Habitación de uso individual
+      - Sujeto a disponibilidad
+    
+  </PricingItem>
+
+  <PricingItem title="Seguro de anulación (Opcional)" price="00 €" subtitle="Tipo de seguro">
+   
+    - Descripción de coberturas
+    - Gastos médicos: 00.000 €
+    
+    <Button title="GARANTIAS" icon="fa-solid fa-shield-halved" link="#" className="pricing-button" />
+
+  </PricingItem>
+</PricingGrid>
+
+<IncludeExclude>
+  <div slot="included">
+    - Transporte (avión, bus, etc.).
+    - Alojamiento en hoteles de X estrellas.
+    - Tasas aéreas y de aeropuerto.
+    - Equipaje incluido.
+    - Guía local de habla española.
+    - Entradas a monumentos mencionados.
+    - Régimen de comidas especificado.
+    - Guía acompañante desde España.
+  </div>
+  <div slot="excluded">
+    - Comidas y cenas no mencionadas.
+    - Bebidas en las comidas.
+    - Propinas y maleteros.
+    - Extras personales.
+    - Seguros opcionales.
+    - Todo lo no especificado en el apartado "Incluye".
+  </div>
+</IncludeExclude>
+
+## Hoteles previstos o similares
+
+- **Ciudad 1**: Nombre del Hotel
+- **Ciudad 2**: Nombre del Hotel
+
+## Vuelos
+
+<FlightGrid>
+  <FlightItem 
+    date="DD MES" 
+    origin="Ciudad Origen" 
+    destination="Ciudad Destino" 
+    airline="Compañía" 
+    times="00:00 – 00:00" 
+    type="takeoff"
+  />
+  <FlightItem 
+    date="DD MES" 
+    origin="Ciudad Destino" 
+    destination="Ciudad Origen" 
+    airline="Compañía" 
+    times="00:00 – 00:00" 
+    type="landing"
+  />
+</FlightGrid>
+
+## Plazos de pago
+
+| Fecha | Importe |
+| --- | --- |
+| Fecha de reserva | 000 € |
+| Fecha intermedia | 000 € |
+| Fecha final | Resto pendiente |
+
+## Gastos de anulación según fecha de salida
+
+| Desde | Hasta | Importe |
+| --- | --- | --- |
+| Fecha de reserva | Día de salida | 000 € |
+| X días antes | Y días antes | 50 % |
+| Z días antes | 0 días | 100 % |
+
+## Observaciones
+
+- Se ha establecido un pago inicial de **000 €** para confirmar la reserva.
+- Es necesario comunicar alergias o intolerancias alimentarias.
+- El precio puede ser revisado según la normativa vigente (combustible, tasas, etc.).
+
+## Pagos
+
+- Los pagos se podrán realizar en la oficina de Viajes Veleta o mediante transferencia a la siguiente cuenta de **Caja Rural**:
+- Titular: **Viajes Veleta**
+- Cuenta: **ES95 3023 0148 2955 1682 4504**


### PR DESCRIPTION
## Summary
- Add a new reusable MDX template for group trip pages at `src/content/viajes-en-grupo/plantilla-viaje-en-grupo.mdx`
- Include standardized sections for itinerary, pricing, inclusions/exclusions, flights, payment schedule, and cancellation terms
- Provide placeholders and component structure to speed up publishing future group trip content

## Test plan
- [x] Confirm file is valid frontmatter + MDX structure
- [x] Confirm all expected sections/components are present in the template
- [ ] Run site build locally and verify the template renders correctly when used

Made with [Cursor](https://cursor.com)