### PR TITLE
fix: harden production domain references to viajesveleta.es

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -33,7 +33,7 @@ export default defineConfig({
     adapter: cloudflare({
         imageService: 'passthrough',
     }),
-    site: 'https://example.com',
+    site: 'https://viajesveleta.es',
     prefetch: {
         prefetchAll: true,
         defaultStrategy: 'viewport',

--- a/docs/MULTILANGUAGE_CONTENT_GUIDE.md
+++ b/docs/MULTILANGUAGE_CONTENT_GUIDE.md
@@ -132,16 +132,16 @@ When creating multilanguage content:
 When you create content with the same `id` in multiple languages:
 
 1. **URLs are generated:**
-   - Spanish: `https://yoursite.com/blog/my-amazing-trip/`
-   - English: `https://yoursite.com/en/blog/my-amazing-trip/`
+   - Spanish: `https://viajesveleta.es/blog/my-amazing-trip/`
+   - English: `https://viajesveleta.es/en/blog/my-amazing-trip/`
 
 2. **Language switcher works automatically:**
    - Visitors can switch between Spanish and English versions
    - The site remembers which version they prefer
 
 3. **RSS feeds are separated:**
-   - Spanish posts: `https://yoursite.com/rss.xml`
-   - English posts: `https://yoursite.com/en/rss.xml`
+   - Spanish posts: `https://viajesveleta.es/rss.xml`
+   - English posts: `https://viajesveleta.es/en/rss.xml`
 
 4. **Search engines understand:**
    - Proper `hreflang` tags tell Google about translations

--- a/src/pages/politica-privacidad.astro
+++ b/src/pages/politica-privacidad.astro
@@ -53,14 +53,14 @@ const isFallback = urlParams.get("lang") === "en"; // User wants English but vie
                     Orgánica 15/1999, de 13 de diciembre, de Protección de Datos
                     de Carácter Personal (en adelante LOPD), Viajes Veleta S.
                     L., Guadix, Calle Poetisa Hafsa 3, C. P: 18500 (ESPAÑA),
-                    sociedad propietaria del dominio www.viajesveleta.net, en
+                    sociedad propietaria del dominio www.viajesveleta.es, en
                     adelante LA EMPRESA, le informa que los datos de carácter
                     personal que nos proporcione mediante la cumplimentación de
                     cualquier formulario de registro electrónico que aparece en
                     nuestra página web, así como los datos a los que LA EMPRESA
                     acceda como consecuencia de su navegación, consulta,
                     solicitud u operación realizada a través de la página web de
-                    www.viajesveleta.net, serán recogidos en un fichero cuyo
+                    www.viajesveleta.es, serán recogidos en un fichero cuyo
                     responsable es la EMPRESA. Usted podrá ejercer sus derechos
                     de acceso, rectificación, cancelación y oposición al
                     tratamiento de sus datos personales, en los términos y
@@ -71,7 +71,7 @@ const isFallback = urlParams.get("lang") === "en"; // User wants English but vie
                     Para su mayor comodidad, la EMPRESA le ofrece la posibilidad
                     de ejercer los derechos antes referidos mediante la
                     siguiente dirección de correo electrónico <strong
-                        >guadix@viajesveleta.net</strong
+                        >guadix@viajesveleta.es</strong
                     >.
                 </p>
                 <p>


### PR DESCRIPTION
Summary:\n- set Astro site to https://viajesveleta.es\n- replace legacy .net references in privacy policy\n- update multilingual guide example URLs\n\nValidation:\n- ASTRO_TELEMETRY_DISABLED=1 npm run check\n- ASTRO_TELEMETRY_DISABLED=1 npm run build\n- verified sitemap/canonical output points to https://viajesveleta.es