### PR TITLE
feat: añadir excursiones opcionales, cenas detalladas y actualizar seguros para viajes a China

### DIFF
--- a/src/content/viajes-en-grupo/es/china-tras-las-huellas-del-dragon.mdx
+++ b/src/content/viajes-en-grupo/es/china-tras-las-huellas-del-dragon.mdx
@@ -226,16 +226,24 @@ location: ["Pekín", "Xi'an", "Guilin", "Hangzhou", "Suzhou", "Shanghái"]
         - Seguro de inclusión y documentación de viaje.
     </div>
     <div slot="excluded">
-        - Almuerzos y cenas no indicados en el itinerario.
-        - Bebidas en almuerzos y cenas.
-        - Excursiones opcionales:
+- Almuerzos y cenas no indicados en el itinerario.
+- Bebidas en almuerzos y cenas.
+- Excursiones opcionales:
     - Musical Dinastía Tang (Xi’An): 54 €
-        - Guía acompañante desde España.
-        - Extras personales, como teléfono, comidas y bebidas no descritas, lavandería, etc.
-        - Propinas.
-        - Seguros opcionales de cancelación.
-        - Servicios no especificados en el apartado EL PRECIO INCLUYE.
-    </div>
+- Cenas opcionales: 335 €
+    - Pekín: Cena buffet en Beijing Xinqiao Hotel (2 noches)
+    - Xi’an: Cena buffet en Holiday Inn xi'an High-Tech Zone (2 noches)
+    - Guilin: Cena menú occidental en Guilin Guilin Bravo Hotel (2 noches)
+    - Hangzhou: Cena buffet en Hangzhou Landison Plaza International Hotel Zhejiang (2 noches)
+    - Suzhou: Cena buffet en Suzhou UrCove Suzhou Shantang Street (1 noche)
+    - Shanghai: Cena buffet en UrCove by HYATT Shanghai Jing'an (2 noches)
+    - Total Noches: 11
+- Guía acompañante desde España.
+- Extras personales, como teléfono, comidas y bebidas no descritas, lavandería, etc.
+- Propinas.
+- Seguros opcionales de cancelación.
+- Servicios no especificados en el apartado EL PRECIO INCLUYE.
+</div>
 </IncludeExclude>
 
 <div style="margin-top: 2rem;"></div>

--- a/src/content/viajes-en-grupo/es/china-tras-las-huellas-del-dragon.mdx
+++ b/src/content/viajes-en-grupo/es/china-tras-las-huellas-del-dragon.mdx
@@ -185,28 +185,28 @@ location: ["Pekín", "Xi'an", "Guilin", "Hangzhou", "Suzhou", "Shanghái"]
 
     </PricingItem>
 
-    <PricingItem title="Seguro de anulación" price="70 €" subtitle="Prime 2.0">
+<PricingItem title="Seguro de anulación" price="70 €" subtitle="Prime 2.0">
+    
+    - No cubre enfermedades preexistentes
+    - Gastos médicos: 1.500.000 €
+    - Gastos de anulación: 1.500.000 €
+    
+    <Button title="GARANTIAS" icon="fa-solid fa-shield-halved"
+            link="https://www.bujaldon-sl.com/productos/garantias/prime-2-0" className="pricing-button"/>
+    
+</PricingItem>
 
-        - No cubre enfermedades preexistentes
-        - Gastos médicos: 450.000 €
-        - Gastos de anulación: 3.000 €
-
-        <Button title="GARANTIAS" icon="fa-solid fa-shield-halved"
-                link="https://www.bujaldon-sl.com/productos/garantias/prime-2-0" className="pricing-button"/>
-
-    </PricingItem>
-
-    <PricingItem title="Seguro de anulación" price="80 €" subtitle="Prime Preexistencias 2.0">
-
-        - Cubre enfermedades preexistentes
-        - Gastos médicos: 500.000 €
-        - Gastos de anulación: 3.000 €
-
-        <Button title="GARANTIAS" icon="fa-solid fa-shield-halved"
-                link="https://www.bujaldon-sl.com/productos/garantias/prime-preexistencias-2-0"
-                className="pricing-button"/>
-
-    </PricingItem>
+<PricingItem title="Seguro de anulación" price="80 €" subtitle="Prime Preexistencias 2.0">
+    
+    - Cubre enfermedades preexistentes
+    - Gastos médicos: 1.500.000 €
+    - Gastos de anulación: 1.500.000 €
+    
+    <Button title="GARANTIAS" icon="fa-solid fa-shield-halved"
+            link="https://www.bujaldon-sl.com/productos/garantias/prime-preexistencias-2-0"
+            className="pricing-button"/>
+    
+</PricingItem>
 </PricingGrid>
 
 <IncludeExclude>

--- a/src/content/viajes-en-grupo/es/china-tras-las-huellas-del-dragon.mdx
+++ b/src/content/viajes-en-grupo/es/china-tras-las-huellas-del-dragon.mdx
@@ -228,7 +228,8 @@ location: ["Pekín", "Xi'an", "Guilin", "Hangzhou", "Suzhou", "Shanghái"]
     <div slot="excluded">
         - Almuerzos y cenas no indicados en el itinerario.
         - Bebidas en almuerzos y cenas.
-        - Excursiones opcionales.
+        - Excursiones opcionales:
+    - Musical Dinastía Tang (Xi’An): 54 €
         - Guía acompañante desde España.
         - Extras personales, como teléfono, comidas y bebidas no descritas, lavandería, etc.
         - Propinas.

--- a/src/content/viajes-en-grupo/es/tesoros-escondidos-de-china.mdx
+++ b/src/content/viajes-en-grupo/es/tesoros-escondidos-de-china.mdx
@@ -101,24 +101,24 @@ location: ["Pekín", "Xi'an", "Chongqing", "Zhangjiajie", "Shanghái"]
   </PricingItem>
 
 <PricingItem title="Seguro de anulación" price="70 €" subtitle="Prime 2.0">
-    
-    - No cubre enfermedades preexistentes
-    - Gastos médicos: 450.000 €
-    - Gastos de anulación: 3.000 €
-    
-    <Button title="GARANTIAS" icon="fa-solid fa-shield-halved" link="https://www.bujaldon-sl.com/productos/garantias/prime-2-0" className="pricing-button" />
-    
-  </PricingItem>
+     
+     - No cubre enfermedades preexistentes
+     - Gastos médicos: 1.500.000 €
+     - Gastos de anulación: 1.500.000 €
+     
+     <Button title="GARANTIAS" icon="fa-solid fa-shield-halved" link="https://www.bujaldon-sl.com/productos/garantias/prime-2-0" className="pricing-button" />
+     
+   </PricingItem>
 
-  <PricingItem title="Seguro de anulación" price="80 €" subtitle="Prime Preexistencias 2.0">
-    
-    - Cubre enfermedades preexistentes
-    - Gastos médicos: 500.000 €
-    - Gastos de anulación: 3.000 €
-    
-    <Button title="GARANTIAS" icon="fa-solid fa-shield-halved" link="https://www.bujaldon-sl.com/productos/garantias/prime-preexistencias-2-0" className="pricing-button" />
-    
-  </PricingItem>
+<PricingItem title="Seguro de anulación" price="80 €" subtitle="Prime Preexistencias 2.0">
+     
+     - Cubre enfermedades preexistentes
+     - Gastos médicos: 1.500.000 €
+     - Gastos de anulación: 1.500.000 €
+     
+     <Button title="GARANTIAS" icon="fa-solid fa-shield-halved" link="https://www.bujaldon-sl.com/productos/garantias/prime-preexistencias-2-0" className="pricing-button" />
+     
+   </PricingItem>
 </PricingGrid>
 
 <IncludeExclude>

--- a/src/content/viajes-en-grupo/es/tesoros-escondidos-de-china.mdx
+++ b/src/content/viajes-en-grupo/es/tesoros-escondidos-de-china.mdx
@@ -136,24 +136,24 @@ location: ["Pekín", "Xi'an", "Chongqing", "Zhangjiajie", "Shanghái"]
     - Seguro de inclusión y documentación de viaje.
   </div>
   <div slot="excluded">
-   - Almuerzos y cenas no indicados en el itinerario.
-   - Bebidas en almuerzos y cenas.
-    - Excursiones opcionales:
-      - Tour Street Food (Xi’An): 40 €
-      - Musical Dinastía Tang (Xi’An): 54 €
-    - Cenas opcionales: 275 €
-      - Pekín: Cena buffet en Beijing Xinqiao Hotel (2 noches)
-      - Xi’an: Cena buffet en Holiday Inn xi'an High-Tech Zone (2 noches)
-      - Chongqing: Cena buffet comida china en Chongqing Mercure Downtown (1 noche)
-      - Zhangjiajie: Cena buffet en Neodalle Resort Zhangjiajie (2 noches)
-      - Shanghai: Cena buffet en UrCove by HYATT Shanghai Jing'an (2 noches)
-      - Total Noches: 9
-    - Guía acompañante desde España.
-   - Extras personales, como teléfono, comidas y bebidas no descritas, lavandería, etc.
-   - Propinas.
-   - Seguros opcionales de cancelación.
-   - Servicios no especificados en el apartado "El precio incluye".
-  </div>
+- Almuerzos y cenas no indicados en el itinerario.
+- Bebidas en almuerzos y cenas.
+- Excursiones opcionales:
+    - Tour Street Food (Xi’An): 40 €
+    - Musical Dinastía Tang (Xi’An): 54 €
+- Cenas opcionales: 275 €
+    - Pekín: Cena buffet en Beijing Xinqiao Hotel (2 noches)
+    - Xi’an: Cena buffet en Holiday Inn xi'an High-Tech Zone (2 noches)
+    - Chongqing: Cena buffet comida china en Chongqing Mercure Downtown (1 noche)
+    - Zhangjiajie: Cena buffet en Neodalle Resort Zhangjiajie (2 noches)
+    - Shanghai: Cena buffet en UrCove by HYATT Shanghai Jing'an (2 noches)
+    - Total Noches: 9
+- Guía acompañante desde España.
+- Extras personales, como teléfono, comidas y bebidas no descritas, lavandería, etc.
+- Propinas.
+- Seguros opcionales de cancelación.
+- Servicios no especificados en el apartado "El precio incluye".
+</div>
 </IncludeExclude>
 
 ## Hoteles previstos o similares

--- a/src/content/viajes-en-grupo/es/tesoros-escondidos-de-china.mdx
+++ b/src/content/viajes-en-grupo/es/tesoros-escondidos-de-china.mdx
@@ -136,24 +136,33 @@ location: ["Pekín", "Xi'an", "Chongqing", "Zhangjiajie", "Shanghái"]
     - Seguro de inclusión y documentación de viaje.
   </div>
   <div slot="excluded">
-    - Almuerzos y cenas no indicados en el itinerario.
-    - Bebidas en almuerzos y cenas.
-    - Excursiones opcionales.
+   - Almuerzos y cenas no indicados en el itinerario.
+   - Bebidas en almuerzos y cenas.
+    - Excursiones opcionales:
+      - Tour Street Food (Xi’An): 40 €
+      - Musical Dinastía Tang (Xi’An): 54 €
+    - Cenas opcionales: 275 €
+      - Pekín: Cena buffet en Beijing Xinqiao Hotel (2 noches)
+      - Xi’an: Cena buffet en Holiday Inn xi'an High-Tech Zone (2 noches)
+      - Chongqing: Cena buffet comida china en Chongqing Mercure Downtown (1 noche)
+      - Zhangjiajie: Cena buffet en Neodalle Resort Zhangjiajie (2 noches)
+      - Shanghai: Cena buffet en UrCove by HYATT Shanghai Jing'an (2 noches)
+      - Total Noches: 9
     - Guía acompañante desde España.
-    - Extras personales, como teléfono, comidas y bebidas no descritas, lavandería, etc.
-    - Propinas.
-    - Seguros opcionales de cancelación.
-    - Servicios no especificados en el apartado "El precio incluye".
+   - Extras personales, como teléfono, comidas y bebidas no descritas, lavandería, etc.
+   - Propinas.
+   - Seguros opcionales de cancelación.
+   - Servicios no especificados en el apartado "El precio incluye".
   </div>
 </IncludeExclude>
 
 ## Hoteles previstos o similares
 
-- **Pekín**: Hotel de categoría 4* en el centro histórico.
-- **Xi’an**: Hotel urbano 4* próximo a la muralla.
-- **Chongqing**: Hotel 4* con vistas al río Yangtsé.
-- **Zhangjiajie**: Hotel rural 4* cerca del parque nacional.
-- **Shanghái**: Hotel 4* céntrico junto al Bund.
+- **Pekín**: Xin Qiao
+- **Xi’an**: Holiday Inn Xian High Tech
+- **Chongqing**: Mercure Downtown
+- **Zhangjiajie**: Expert Village Sunshine Courtyard
+- **Shanghái**: Golden Tulip Rainbow Shanghai
 
 ## Vuelos
 


### PR DESCRIPTION
Este PR incluye los siguientes cambios para los viajes a China:

## Tesoros escondidos de China
- Añadidas excursiones opcionales:
  - Tour Street Food (Xi’An): 40 €
  - Musical Dinastía Tang (Xi’An): 54 €
- Añadidas cenas opcionales detalladas: 275 €
  - Pekín: Cena buffet en Beijing Xinqiao Hotel (2 noches)
  - Xi’an: Cena buffet en Holiday Inn xi'an High-Tech Zone (2 noches)
  - Chongqing: Cena buffet comida china en Chongqing Mercure Downtown (1 noche)
  - Zhangjiajie: Cena buffet en Neodalle Resort Zhangjiajie (2 noches)
  - Shanghai: Cena buffet en UrCove by HYATT Shanghai Jing'an (2 noches)
  - Total Noches: 9
- Actualizados seguros Prime 2.0 y Prime Preexistencias 2.0: gastos médicos y de anulación a 1.500.000 € cada uno
- Ajustado formato de viñetas en 'Precio no incluye' para consistencia

## China: tras las huellas del dragón
- Añadida excursión opcional:
  - Musical Dinastía Tang (Xi’An): 54 €
- Añadidas cenas opcionales detalladas: 335 €
  - Pekín: Cena buffet en Beijing Xinqiao Hotel (2 noches)
  - Xi’an: Cena buffet en Holiday Inn xi'an High-Tech Zone (2 noches)
  - Guilin: Cena menú occidental en Guilin Guilin Bravo Hotel (2 noches)
  - Hangzhou: Cena buffet en Hangzhou Landison Plaza International Hotel Zhejiang (2 noches)
  - Suzhou: Cena buffet en Suzhou UrCove Suzhou Shantang Street (1 noche)
  - Shanghai: Cena buffet en UrCove by HYATT Shanghai Jing'an (2 noches)
  - Total Noches: 11
- Actualizados seguros Prime 2.0 y Prime Preexistencias 2.0: gastos médicos y de anulación a 1.500.000 € cada uno
- Ajustado formato de viñetas en 'Precio no incluye' para consistencia

Todos los cambios han sido verificados con 
> viajes-veleta-web@0.0.1 build
> npm run check && astro build


> viajes-veleta-web@0.0.1 check
> astro check

13:36:57 [@astrojs/cloudflare] Enabling sessions with Cloudflare KV with the "SESSION" KV binding.
13:36:57 [@astrojs/cloudflare] If you see the error "Invalid binding `SESSION`" in your build output, you need to add the binding to your wrangler config file.
13:36:57 [content] Syncing content
13:36:57 [content] Synced content
13:36:57 [types] Generated 125ms
13:36:57 [check] Getting diagnostics for Astro files in /Users/melania/Documentos/viajes-veleta-web...
[96msrc/components/Gallery.astro[0m:[93m112[0m:[93m25[0m - [93mwarning[0m[90m ts(6133): [0m'el' is declared but its value is never read.

[7m112[0m   window.openGallery = (el, idx) => {
[7m   [0m [93m                        ~~[0m

[96msrc/components/Header.astro[0m:[93m24[0m:[93m2[0m - [93mwarning[0m[90m ts(6133): [0m'translatedPaths' is declared but its value is never read.

[7m24[0m  translatedPaths,
[7m  [0m [93m ~~~~~~~~~~~~~~~[0m
[96msrc/components/Header.astro[0m:[93m8[0m:[93m1[0m - [93mwarning[0m[90m ts(6133): [0m'LanguagePicker' is declared but its value is never read.

[7m8[0m import LanguagePicker from "./LanguagePicker.astro";
[7m [0m [93m~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~[0m
[96msrc/components/Header.astro[0m:[93m7[0m:[93m1[0m - [93mwarning[0m[90m ts(6133): [0m'Search' is declared but its value is never read.

[7m7[0m import Search from "./Search.astro";
[7m [0m [93m~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~[0m
[96msrc/components/Header.astro[0m:[93m4[0m:[93m1[0m - [93mwarning[0m[90m ts(6133): [0m'ThemeToggle' is declared but its value is never read.

[7m4[0m import ThemeToggle from "./ThemeToggle.astro";
[7m [0m [93m~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~[0m

[96msrc/pages/_en/_ofertas/[...slug].astro[0m:[93m20[0m:[93m42[0m - [93mwarning[0m[90m ts(6133): [0m'id' is declared but its value is never read.

[7m20[0m     return Object.entries(grouped).map(([id, translations]) => {
[7m  [0m [93m                                         ~~[0m

[96msrc/pages/_en/viajes-en-grupo/[...slug].astro[0m:[93m32[0m:[93m42[0m - [93mwarning[0m[90m ts(6133): [0m'id' is declared but its value is never read.

[7m32[0m     return Object.entries(grouped).map(([id, translations]) => {
[7m  [0m [93m                                         ~~[0m

[96msrc/pages/_ofertas/[...slug].astro[0m:[93m20[0m:[93m42[0m - [93mwarning[0m[90m ts(6133): [0m'id' is declared but its value is never read.

[7m20[0m     return Object.entries(grouped).map(([id, translations]) => {
[7m  [0m [93m                                         ~~[0m

[96msrc/pages/viajes-en-grupo/[...slug].astro[0m:[93m32[0m:[93m42[0m - [93mwarning[0m[90m ts(6133): [0m'id' is declared but its value is never read.

[7m32[0m     return Object.entries(grouped).map(([id, translations]) => {
[7m  [0m [93m                                         ~~[0m

Result (68 files): 
- 0 errors
- 0 warnings
- 9 hints

13:37:00 [@astrojs/cloudflare] Enabling sessions with Cloudflare KV with the "SESSION" KV binding.
13:37:00 [@astrojs/cloudflare] If you see the error "Invalid binding `SESSION`" in your build output, you need to add the binding to your wrangler config file.
13:37:00 [content] Syncing content
13:37:00 [content] Synced content
13:37:00 [types] Generated 118ms
13:37:00 [build] output: "static"
13:37:00 [build] mode: "server"
13:37:00 [build] directory: /Users/melania/Documentos/viajes-veleta-web/dist/
13:37:00 [build] adapter: @astrojs/cloudflare
13:37:00 [build] Collecting build info...
13:37:00 [build] ✓ Completed in 127ms.
13:37:00 [build] Building server entrypoints...
13:37:01 [vite] ✓ built in 1.02s
13:37:01 [build] ✓ Completed in 1.03s.

 building client (vite) 
13:37:01 [vite] transforming...
13:37:01 [vite] ✓ 55 modules transformed.
13:37:01 [vite] rendering chunks...
13:37:01 [vite] computing gzip size...
13:37:01 [vite] dist/_astro/page.ZXyU73wm.js                                                  0.05 kB │ gzip:  0.07 kB
13:37:01 [vite] dist/_astro/_tag_.astro_astro_type_script_index_0_lang.BC7hmHTH.js            0.56 kB │ gzip:  0.37 kB
13:37:01 [vite] dist/_astro/index.KOfHF6jZ.js                                                 2.31 kB │ gzip:  1.05 kB
13:37:01 [vite] dist/_astro/GroupTripsGrid.astro_astro_type_script_index_0_lang.KR3fvLVP.js   2.90 kB │ gzip:  1.18 kB
13:37:01 [vite] dist/_astro/index.esm.XmLcqY08.js                                             6.66 kB │ gzip:  2.58 kB
13:37:01 [vite] dist/_astro/ClientRouter.astro_astro_type_script_index_0_lang.Bh4wqtPV.js    13.11 kB │ gzip:  4.56 kB
13:37:01 [vite] dist/_astro/HomeSlider.astro_astro_type_script_index_0_lang.DzyJrEC9.js      78.80 kB │ gzip: 24.25 kB
13:37:01 [vite] ✓ built in 115ms

 prerendering static routes 
13:37:01 ▶ src/pages/condiciones-generales.astro
13:37:01   └─ /condiciones-generales/index.html (+9ms) 
13:37:01 ▶ src/pages/contacto.astro
13:37:01   └─ /contacto/index.html (+2ms) 
13:37:01 ▶ src/pages/contrato-viaje-combinado.astro
13:37:01   └─ /contrato-viaje-combinado/index.html (+1ms) 
13:37:01 ▶ src/pages/politica-privacidad.astro
13:37:01   └─ /politica-privacidad/index.html (+1ms) 
13:37:01 ▶ src/pages/style-guide.mdx
13:37:01   └─ /style-guide/index.html (+4ms) 
13:37:01 ▶ src/pages/tags/[tag].astro
13:37:01   ├─ /tags/viajes-en-grupo/index.html (+2ms) 
13:37:01   ├─ /tags/china/index.html (+1ms) 
13:37:01   ├─ /tags/cultura/index.html (+1ms) 
13:37:01   ├─ /tags/alemania/index.html (+2ms) 
13:37:01   ├─ /tags/francia/index.html (+1ms) 
13:37:01   ├─ /tags/selva-negra/index.html (+1ms) 
13:37:01   ├─ /tags/alsacia/index.html (+1ms) 
13:37:01   ├─ /tags/europa/index.html (+1ms) 
13:37:01   ├─ /tags/espana/index.html (+1ms) 
13:37:01   ├─ /tags/experiencia-fotografica/index.html (+1ms) 
13:37:01   ├─ /tags/naturaleza/index.html (+1ms) 
13:37:01   ├─ /tags/noruega/index.html (+1ms) 
13:37:01   ├─ /tags/lofoten/index.html (+1ms) 
13:37:01   ├─ /tags/paisajes/index.html (+1ms) 
13:37:01   ├─ /tags/ártico/index.html (+1ms) 
13:37:01   ├─ /tags/asia/index.html (+1ms) 
13:37:01   ├─ /tags/oferta/index.html (+1ms) 
13:37:01   ├─ /tags/bali/index.html (+1ms) 
13:37:01   ├─ /tags/relax/index.html (+1ms) 
13:37:01   ├─ /tags/group-travel/index.html (+1ms) 
13:37:01   ├─ /tags/sicily/index.html (+1ms) 
13:37:01   ├─ /tags/italy/index.html (+1ms) 
13:37:01   ├─ /tags/mediterranean/index.html (+1ms) 
13:37:01   ├─ /tags/culture/index.html (+1ms) 
13:37:01   ├─ /tags/offer/index.html (+1ms) 
13:37:01   ├─ /tags/bali/index.html (+1ms) 
13:37:01   └─ /tags/relax/index.html (+6ms) 
13:37:02 ▶ src/pages/tags/index.astro
13:37:02   └─ /tags/index.html (+1ms) 
13:37:02 ▶ src/pages/viajes-en-grupo/index.astro
13:37:02   └─ /viajes-en-grupo/index.html (+2ms) 
13:37:02 ▶ src/pages/viajes-en-grupo/[...slug].astro
13:37:02   ├─ /viajes-en-grupo/china-tras-las-huellas-del-dragon/index.html (+5ms) 
13:37:02   ├─ /viajes-en-grupo/sicilia-el-alma-del-mediterraneo/index.html (+4ms) 
13:37:02   ├─ /viajes-en-grupo/rutas-secretas-por-la-selva-negra-y-alsacia/index.html (+3ms) 
13:37:02   ├─ /viajes-en-grupo/paisajes-y-colores-de-otono-en-ordesa/index.html (+4ms) 
13:37:02   ├─ /viajes-en-grupo/la-belleza-de-los-paisajes-árticos-lofoten/index.html (+5ms) 
13:37:02   └─ /viajes-en-grupo/tesoros-escondidos-de-china/index.html (+3ms) 
13:37:02 ▶ src/pages/index.astro
13:37:02   └─ /index.html (+3ms) 
13:37:02 ✓ Completed in 90ms.

 generating optimized images 
13:37:02   ▶ /_astro/logo.bwyuxqUZ_19DKCs.svg (reused cache entry) (+1ms) (1/103)
13:37:02   ▶ /_astro/blog-hero.CSHOiAxL_Z2l6W7G.webp (reused cache entry) (+2ms) (2/103)
13:37:02   ▶ /_astro/selva-negra-header.BO08JIqo_Z1eHav.webp (reused cache entry) (+2ms) (3/103)
13:37:02   ▶ /_astro/contacto-fachada.D6jbe-Uj_11XbDE.webp (reused cache entry) (+2ms) (4/103)
13:37:02   ▶ /_astro/contacto-interior._PRFhseA_mFiD8.webp (reused cache entry) (+3ms) (5/103)
13:37:02   ▶ /_astro/tesoros-escondidos-de-china.CWOXx4eD_Z1GLOke.webp (reused cache entry) (+3ms) (6/103)
13:37:02   ▶ /_astro/blog-placeholder-about.CD-SSdA5_1wWkDc.webp (reused cache entry) (+2ms) (7/103)
13:37:02   ▶ /_astro/blog-placeholder-3.B5DWqi2J_872d8.webp (reused cache entry) (+3ms) (8/103)
13:37:02   ▶ /_astro/blog-placeholder-2.V-pEviCa_Z25V3s7.webp (reused cache entry) (+3ms) (9/103)
13:37:02   ▶ /_astro/lofoten-hero.wpT4xa1A_pXhNC.webp (reused cache entry) (+2ms) (10/103)
13:37:02   ▶ /_astro/blog-placeholder-1.BWHNx_m5_EfkRc.webp (reused cache entry) (+2ms) (11/103)
13:37:02   ▶ /_astro/paisajes-y-colores-de-otono-en-ordesa-hero.Czic-7Iq_Zk3Nb5.webp (reused cache entry) (+2ms) (12/103)
13:37:02   ▶ /_astro/viajes-en-grupo.CrUpVbRB_1fQCml.webp (reused cache entry) (+2ms) (13/103)
13:37:02   ▶ /_astro/china-dia-10.maSzQsIu_ZatUku.webp (reused cache entry) (+3ms) (14/103)
13:37:02   ▶ /_astro/segesta.B2UdmVo4_1UMYxC.webp (reused cache entry) (+3ms) (15/103)
13:37:02   ▶ /_astro/dia-1.CYPr6ot8_2w923P.webp (reused cache entry) (+2ms) (16/103)
13:37:02   ▶ /_astro/china-dia-2-2.DPGUSb0N_Z2nkrSF.webp (reused cache entry) (+3ms) (17/103)
13:37:02   ▶ /_astro/dia-2.DzqqowX5_Z1gz504.jpg (reused cache entry) (+3ms) (18/103)
13:37:02   ▶ /_astro/china-tras-las-huellas-del-dragon-mapa.DfFm7pZg_ZyVxLz.webp (reused cache entry) (+5ms) (19/103)
13:37:02   ▶ /_astro/china-dia-5.B0hU3goL_Z1N8F8j.webp (reused cache entry) (+4ms) (20/103)
13:37:02   ▶ /_astro/china-dia-4.BV7W0kLz_14Suci.webp (reused cache entry) (+4ms) (21/103)
13:37:02   ▶ /_astro/dia-6.KcdUxibI_Z1is0TC.webp (reused cache entry) (+4ms) (22/103)
13:37:02   ▶ /_astro/dia-4.BFoI9epw_r7Hoe.jpg (reused cache entry) (+5ms) (23/103)
13:37:02   ▶ /_astro/china-dia-8.CXc3MpCl_qRTFL.webp (reused cache entry) (+3ms) (24/103)
13:37:02   ▶ /_astro/china-dia-9.DRKgtK44_ZwHTYV.webp (reused cache entry) (+3ms) (25/103)
13:37:02   ▶ /_astro/china-dia-11.CNnvjH_O_1m4gUa.webp (reused cache entry) (+2ms) (26/103)
13:37:02   ▶ /_astro/china-dia-12.CISgR1y8_ZAn4iS.webp (reused cache entry) (+2ms) (27/103)
13:37:02   ▶ /_astro/mapa.C-q2hRBc_TBp32.webp (reused cache entry) (+1ms) (28/103)
13:37:02   ▶ /_astro/china-dia-7.CGpYP_dv_Z1w98AV.webp (reused cache entry) (+6ms) (29/103)
13:37:02   ▶ /_astro/vueling.DWa_9k85_Z2dEnhx.webp (reused cache entry) (+2ms) (30/103)
13:37:02   ▶ /_astro/china-dia-13.BlTNuOED_ZWsIBL.webp (reused cache entry) (+3ms) (31/103)
13:37:02   ▶ /_astro/templo-concordia.BuHzarBp_Z1zSSdK.webp (reused cache entry) (+7ms) (32/103)
13:37:02   ▶ /_astro/china-dia-14.D5ur71_t_1N99Si.webp (reused cache entry) (+8ms) (33/103)
13:37:02   ▶ /_astro/taormina.Doiu_vy6_ZkMTO.webp (reused cache entry) (+7ms) (34/103)
13:37:02   ▶ /_astro/ragusa.BvtJNsWg_mL4NI.webp (reused cache entry) (+8ms) (35/103)
13:37:02   ▶ /_astro/cefalu.BkbjrqIJ_ZzQBnU.webp (reused cache entry) (+8ms) (36/103)
13:37:02   ▶ /_astro/monreale.ChK5Hu7d_2sas4E.webp (reused cache entry) (+8ms) (37/103)
13:37:02   ▶ /_astro/erice.BlDJKHS7_OExzP.webp (reused cache entry) (+9ms) (38/103)
13:37:02   ▶ /_astro/air-europa.D32_lX3I_ZHObL7.webp (reused cache entry) (+4ms) (39/103)
13:37:02   ▶ /_astro/selva-negra-y-alsacia-mapa.bVOnm9rI_Z1kCakI.webp (reused cache entry) (+4ms) (40/103)
13:37:02   ▶ /_astro/palermo.guit2Wwo_1GAu4X.webp (reused cache entry) (+10ms) (41/103)
13:37:02   ▶ /_astro/gengenbach.B5JgiwYB_1XqJEJ.webp (reused cache entry) (+5ms) (42/103)
13:37:02   ▶ /_astro/triberg.D1vC-7gK_JLAUF.webp (reused cache entry) (+4ms) (43/103)
13:37:02   ▶ /_astro/lago-constanza.Q_EQoB-u_2jJ1Ex.webp (reused cache entry) (+5ms) (44/103)
13:37:02   ▶ /_astro/colmar.O7vTutFC_Z1Dej6m.webp (reused cache entry) (+5ms) (45/103)
13:37:02   ▶ /_astro/frankfurt.BfXh8yy2_Z9EoML.webp (reused cache entry) (+3ms) (46/103)
13:37:02   ▶ /_astro/heidelberg.45HRM-4U_Z1l5pWR.webp (reused cache entry) (+4ms) (47/103)
13:37:02   ▶ /_astro/estrasburgo.BFpn13Z6_ZmhdDu.webp (reused cache entry) (+5ms) (48/103)
13:37:02   ▶ /_astro/ordesa-dia-1.DW2FWL33_1l749z.webp (reused cache entry) (+5ms) (49/103)
13:37:02   ▶ /_astro/ordesa-dia-3.DVJOXDY-_12VbLx.webp (reused cache entry) (+3ms) (50/103)
13:37:02   ▶ /_astro/paisajes-y-colores-de-otono-en-ordesa-mapa.WccDYYJe_1HXDmF.webp (reused cache entry) (+5ms) (51/103)
13:37:02   ▶ /_astro/ordesa-dia-2.9T-4VOvH_Qipsm.webp (reused cache entry) (+5ms) (52/103)
13:37:02   ▶ /_astro/ordesa-dia-4.DGgJGktq_Z1vHPRE.webp (reused cache entry) (+3ms) (53/103)
13:37:02   ▶ /_astro/miguel-gil-leon-2.CxUY7GMx_52DyC.webp (reused cache entry) (+4ms) (54/103)
13:37:02   ▶ /_astro/miguel-gil-leon-1.BV2Q0lrJ_mNUmV.webp (reused cache entry) (+4ms) (55/103)
13:37:02   ▶ /_astro/ordesa-galeria-1.B7D4v7NS_Z1m5F0H.webp (reused cache entry) (+5ms) (56/103)
13:37:02   ▶ /_astro/ordesa-galeria-2.Dls0eCda_L8I25.webp (reused cache entry) (+3ms) (57/103)
13:37:02   ▶ /_astro/ordesa-galeria-4.CAzen50y_dAQOj.webp (reused cache entry) (+3ms) (58/103)
13:37:02   ▶ /_astro/ordesa-galeria-3.C7B4M2Yx_f8l84.webp (reused cache entry) (+4ms) (59/103)
13:37:02   ▶ /_astro/ordesa-galeria-6.ld51cm33_CAPb8.webp (reused cache entry) (+4ms) (60/103)
13:37:02   ▶ /_astro/ordesa-galeria-8.DArPBQpC_1PQCzE.webp (reused cache entry) (+2ms) (61/103)
13:37:02   ▶ /_astro/ordesa-galeria-7.B7BOVXCa_cml57.webp (reused cache entry) (+3ms) (62/103)
13:37:02   ▶ /_astro/ordesa-galeria-5.CVDCGt-X_Z2d6v02.webp (reused cache entry) (+4ms) (63/103)
13:37:02   ▶ /_astro/auroras-boreales-itinerario.C98s3xzc_Z1Fmusd.webp (reused cache entry) (+2ms) (64/103)
13:37:02   ▶ /_astro/reine-hamnoy-itinerario.P2nOC1n-_ZHIAjt.webp (reused cache entry) (+3ms) (65/103)
13:37:02   ▶ /_astro/sunset-skagsanden-itinerario.D_YdzuUg_ZDs16Y.webp (reused cache entry) (+2ms) (66/103)
13:37:02   ▶ /_astro/auroras-boreales-leknes-itinerario.DCvB-fXz_25lFfV.webp (reused cache entry) (+4ms) (67/103)
13:37:02   ▶ /_astro/blue-house-uttakleiv-itinerario.RcXIFndS_ZxoqEK.webp (reused cache entry) (+4ms) (68/103)
13:37:02   ▶ /_astro/lofoten-mapa.B4jw1QmN_Zahe9Y.webp (reused cache entry) (+6ms) (69/103)
13:37:02   ▶ /_astro/church-twilight-itinerario.CFq3IhVl_ZAoyeP.webp (reused cache entry) (+4ms) (70/103)
13:37:02   ▶ /_astro/flakstad-myrland-itinerario.DY6xhu-1_Z1bBe2F.webp (reused cache entry) (+4ms) (71/103)
13:37:02   ▶ /_astro/vareid-storsandnes-itinerario.BP15NoX1_Z1Kd0PN.webp (reused cache entry) (+5ms) (72/103)
13:37:02   ▶ /_astro/galeria-lofoten-2.CsRgUosp_20KWUm.webp (reused cache entry) (+3ms) (73/103)
13:37:02   ▶ /_astro/galeria-lofoten-4.BvIamd5E_Z8GLko.webp (reused cache entry) (+2ms) (74/103)
13:37:02   ▶ /_astro/galeria-lofoten-1.9onCsUJM_Z2uBEUp.webp (reused cache entry) (+4ms) (75/103)
13:37:02   ▶ /_astro/galeria-lofoten-3.DKv2jagx_RpXJL.webp (reused cache entry) (+3ms) (76/103)
13:37:02   ▶ /_astro/galeria-lofoten-5.CEjAl0CV_1bzvRU.webp (reused cache entry) (+3ms) (77/103)
13:37:02   ▶ /_astro/galeria-lofoten-7.C7F-_b7k_2uUJJ9.webp (reused cache entry) (+2ms) (78/103)
13:37:02   ▶ /_astro/galeria-lofoten-10.DHAJE4qM_2cScO7.webp (reused cache entry) (+2ms) (79/103)
13:37:02   ▶ /_astro/galeria-lofoten-9.CacxicUL_Z2u95Kx.webp (reused cache entry) (+2ms) (80/103)
13:37:02   ▶ /_astro/galeria-lofoten-8.BvCErZoM_ZqX1Rn.webp (reused cache entry) (+3ms) (81/103)
13:37:02   ▶ /_astro/galeria-lofoten-11.ptNzlEiH_ZWQFHM.webp (reused cache entry) (+2ms) (82/103)
13:37:02   ▶ /_astro/galeria-lofoten-12.BHo6OHfd_1o33ow.webp (reused cache entry) (+2ms) (83/103)
13:37:02   ▶ /_astro/galeria-lofoten-6.DLdhGBwc_10C3Bx.webp (reused cache entry) (+3ms) (84/103)
13:37:02   ▶ /_astro/galeria-lofoten-14.BYVNZPbU_Z2ih6Rj.webp (reused cache entry) (+1ms) (85/103)
13:37:02   ▶ /_astro/galeria-lofoten-13.bYKhZzvl_edcm9.webp (reused cache entry) (+1ms) (86/103)
13:37:02   ▶ /_astro/galeria-lofoten-15.Bdd7GPwe_ZBLgdR.webp (reused cache entry) (+1ms) (87/103)
13:37:02   ▶ /_astro/galeria-lofoten-16.B_GKrMge_Z21IlUc.webp (reused cache entry) (+1ms) (88/103)
13:37:02   ▶ /_astro/galeria-lofoten-17.UNs6mKlv_Z19yPyA.webp (reused cache entry) (+2ms) (89/103)
13:37:02   ▶ /_astro/dia-1.DYxK0lSv_Z1XSsDa.jpg (reused cache entry) (+2ms) (90/103)
13:37:02   ▶ /_astro/china-mapa.CZkmIPD9_fFM5q.webp (reused cache entry) (+2ms) (91/103)
13:37:02   ▶ /_astro/dia-6.CGmkIEya_1zvsX4.jpg (reused cache entry) (+2ms) (92/103)
13:37:02   ▶ /_astro/dia-8._t-G3UIM_baDXO.jpg (reused cache entry) (+2ms) (93/103)
13:37:02   ▶ /_astro/dia-3.CX-3cja3_1nUVY2.jpg (reused cache entry) (+4ms) (94/103)
13:37:02   ▶ /_astro/dia-7.BGOuTknv_2tQWTQ.jpg (reused cache entry) (+4ms) (95/103)
13:37:02   ▶ /_astro/dia-10.BbWl4iRo_Z1WdN0m.jpg (reused cache entry) (+3ms) (96/103)
13:37:02   ▶ /_astro/dia-5.DHW6-EXj_XlQxN.jpg (reused cache entry) (+6ms) (97/103)
13:37:02   ▶ /_astro/geomoon.BCq4u-8z_Z1v0wft.webp (reused cache entry) (+3ms) (98/103)
13:37:02   ▶ /_astro/comarca-de-guadix-logo.aKGK4wKS_Zzv7Kz.webp (reused cache entry) (+3ms) (99/103)
13:37:02   ▶ /_astro/dia-12.sz-v5AC1_2fswJL.jpg (reused cache entry) (+5ms) (100/103)
13:37:02   ▶ /_astro/asociacion-intersectorial-de-empresarios-comarca-de-guadix.uWVmfFd5_Z12N81u.webp (reused cache entry) (+4ms) (101/103)
13:37:02   ▶ /_astro/dia-11.DLam7e2w_Z1UxatK.jpg (reused cache entry) (+7ms) (102/103)
13:37:02   ▶ /_astro/dia-9.Fezv4PAf_25NKVg.jpg (reused cache entry) (+9ms) (103/103)
13:37:02 ✓ Completed in 50ms.

13:37:02 [build] Rearranging server assets...
13:37:02 [@astrojs/sitemap] `sitemap-index.xml` created at `dist`
13:37:02 [pagefind] Pagefind indexed 39 pages
13:37:02 [pagefind] Pagefind wrote index to /Users/melania/Documentos/viajes-veleta-web/dist/pagefind
13:37:02 [build] Server built in 1.55s
13:37:02 [build] Complete! exitosamente.