### PR TITLE
Actualiza seguros de anulación (3.000€) y hoteles en viajes China

### DIFF
--- a/src/content/viajes-en-grupo/es/china-tras-las-huellas-del-dragon.mdx
+++ b/src/content/viajes-en-grupo/es/china-tras-las-huellas-del-dragon.mdx
@@ -189,7 +189,7 @@ location: ["Pekín", "Xi'an", "Guilin", "Hangzhou", "Suzhou", "Shanghái"]
     
     - No cubre enfermedades preexistentes
     - Gastos médicos: 1.500.000 €
-    - Gastos de anulación: 1.500.000 €
+    - Gastos de anulación: 3.000 €
     
     <Button title="GARANTIAS" icon="fa-solid fa-shield-halved"
             link="https://www.bujaldon-sl.com/productos/garantias/prime-2-0" className="pricing-button"/>
@@ -200,7 +200,7 @@ location: ["Pekín", "Xi'an", "Guilin", "Hangzhou", "Suzhou", "Shanghái"]
     
     - Cubre enfermedades preexistentes
     - Gastos médicos: 1.500.000 €
-    - Gastos de anulación: 1.500.000 €
+    - Gastos de anulación: 3.000 €
     
     <Button title="GARANTIAS" icon="fa-solid fa-shield-halved"
             link="https://www.bujaldon-sl.com/productos/garantias/prime-preexistencias-2-0"
@@ -255,7 +255,7 @@ location: ["Pekín", "Xi'an", "Guilin", "Hangzhou", "Suzhou", "Shanghái"]
 - **Guilin**: Guilin Bravo Hotel
 - **Hangzhou**: Landison Plaza Int. Zhejiang
 - **Suzhou**: Urcove Suzhou Shantang ST.
-- **Shanghái**: Golden Tulip Rainbow Shangai
+- **Shanghái**: UrCove by HYATT Shanghai Jing'an
 
 ## Vuelos
 

--- a/src/content/viajes-en-grupo/es/tesoros-escondidos-de-china.mdx
+++ b/src/content/viajes-en-grupo/es/tesoros-escondidos-de-china.mdx
@@ -104,7 +104,7 @@ location: ["Pekín", "Xi'an", "Chongqing", "Zhangjiajie", "Shanghái"]
      
      - No cubre enfermedades preexistentes
      - Gastos médicos: 1.500.000 €
-     - Gastos de anulación: 1.500.000 €
+     - Gastos de anulación: 3.000 €
      
      <Button title="GARANTIAS" icon="fa-solid fa-shield-halved" link="https://www.bujaldon-sl.com/productos/garantias/prime-2-0" className="pricing-button" />
      
@@ -114,7 +114,7 @@ location: ["Pekín", "Xi'an", "Chongqing", "Zhangjiajie", "Shanghái"]
      
      - Cubre enfermedades preexistentes
      - Gastos médicos: 1.500.000 €
-     - Gastos de anulación: 1.500.000 €
+     - Gastos de anulación: 3.000 €
      
      <Button title="GARANTIAS" icon="fa-solid fa-shield-halved" link="https://www.bujaldon-sl.com/productos/garantias/prime-preexistencias-2-0" className="pricing-button" />
      
@@ -161,8 +161,8 @@ location: ["Pekín", "Xi'an", "Chongqing", "Zhangjiajie", "Shanghái"]
 - **Pekín**: Xin Qiao
 - **Xi’an**: Holiday Inn Xian High Tech
 - **Chongqing**: Mercure Downtown
-- **Zhangjiajie**: Expert Village Sunshine Courtyard
-- **Shanghái**: Golden Tulip Rainbow Shanghai
+- **Zhangjiajie**: Neodalle Resort Zhangjiajie
+- **Shanghái**: UrCove by HYATT Shanghai Jing'an
 
 ## Vuelos
 


### PR DESCRIPTION
Cambios realizados:

- **Seguros de anulación**: Gastos de anulación cambiados de 1.500.000€ a 3.000€ en ambos viajes (Prime 2.0 y Prime Preexistencias 2.0)
- **Tesoros escondidos de China**: Hotel Zhangjiajie → Neodalle Resort Zhangjiajie, Hotel Shanghái → UrCove by HYATT Shanghai Jing'an
- **Tras la huella del dragón**: Hotel Shanghái → UrCove by HYATT Shanghai Jing'an